### PR TITLE
Corrected indentation

### DIFF
--- a/lib/until.rb
+++ b/lib/until.rb
@@ -1,6 +1,6 @@
 def using_until
-        levitation_force = 6
-        #your code here
+  levitation_force = 6
+  #your code here
     
 end
 

--- a/lib/while.rb
+++ b/lib/while.rb
@@ -1,7 +1,7 @@
 def using_while
-	levitation_force = 6
+  levitation_force = 6
 	
-	#your code here
+  #your code here
 end
 
 


### PR DESCRIPTION
Fixes #24 . Used two spaces per Ruby convention and as found in other Ruby files on Learn.co.